### PR TITLE
Reduce gitpod load time by moving dependencies to dockerize

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+RUN bash -lc "curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh"
+RUN bash -lc "cargo install cargo-generate"
+RUN npm install npm@latest -g

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,8 @@
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
-  - init: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && cargo install cargo-generate && npm install npm@latest -g && npm install --prefix=www www && wasm-pack build
+  - init: npm install npm@latest -g && npm install --prefix=www www && wasm-pack build
     command: npm --prefix=www run start
 
 ports:


### PR DESCRIPTION
Installing all of the rust and npm tooling when creating the workspace
takes a lot of time. This moves some of that init to docker layers so
that they can be pre-built and cached in gitpod.